### PR TITLE
Fix incorrect argument coercion when setting a breakpoint.

### DIFF
--- a/lib/App/MoarVM/Debug.rakumod
+++ b/lib/App/MoarVM/Debug.rakumod
@@ -904,7 +904,7 @@ sub MAIN(
             clearbp $0, $1;
         }
         when /:s [breakpoint|bp][":"|<.ws>]\"(.*?)\" (\d+) (\d?) (\d?) / {
-            breakpoint $0, $1, $2, $3;
+            breakpoint $0, $1, +$2, +$3;
         }
         when /:s release[handles]? (\d+)+ % \s+/ {
             release-handles |$0;


### PR DESCRIPTION
The Match object evaluates to True, even if there's no match, so the arguments 'suspend' and 'stacktrace' always evaluate to True. We have to explicitly cast to Int first.