### PR TITLE
Fixes mangled printing when hitting a breakpoint without a stacktrace.

### DIFF
--- a/lib/App/MoarVM/Debug/Breakpoints.rakumod
+++ b/lib/App/MoarVM/Debug/Breakpoints.rakumod
@@ -5,16 +5,15 @@ use App::MoarVM::Debug::Formatter;
 sub output-breakpoint-notifications(Str $file, Int $line, Supply $notifications) is export {
     say "Receiving breakpoint notifications for $file:$line";
     start {
-        react whenever $notifications.Supply {
-            #.raku.say;
-            with .<frames> -> $frames {
+        react whenever $notifications.Supply -> $sup {
+            with $sup<frames> -> $frames {
                 my @this-backtrace = format-backtrace($frames);
 
                 print-table my @chunks =
-                    "Breakpoint on $file:$line hit by thread &bold($_<thread>)!"
+                    "Breakpoint on $file:$line hit by thread &bold($sup.<thread>)!"
                         => @this-backtrace;;
             } else {
-                say "Breakpoint on $file:$line hit by thread &bold($_<thread>)!";
+                say "Breakpoint on $file:$line hit by thread &bold($sup.<thread>)!";
             }
         }
         CATCH {

--- a/lib/App/MoarVM/Debug/Breakpoints.rakumod
+++ b/lib/App/MoarVM/Debug/Breakpoints.rakumod
@@ -5,15 +5,15 @@ use App::MoarVM::Debug::Formatter;
 sub output-breakpoint-notifications(Str $file, Int $line, Supply $notifications) is export {
     say "Receiving breakpoint notifications for $file:$line";
     start {
-        react whenever $notifications.Supply -> $sup {
+        react whenever $notifications.Supply -> $ev {
             with $sup<frames> -> $frames {
                 my @this-backtrace = format-backtrace($frames);
 
                 print-table my @chunks =
-                    "Breakpoint on $file:$line hit by thread &bold($sup.<thread>)!"
+                    "Breakpoint on $file:$line hit by thread &bold($ev.<thread>)!"
                         => @this-backtrace;;
             } else {
-                say "Breakpoint on $file:$line hit by thread &bold($sup.<thread>)!";
+                say "Breakpoint on $file:$line hit by thread &bold($ev.<thread>)!";
             }
         }
         CATCH {

--- a/lib/App/MoarVM/Debug/Breakpoints.rakumod
+++ b/lib/App/MoarVM/Debug/Breakpoints.rakumod
@@ -6,7 +6,7 @@ sub output-breakpoint-notifications(Str $file, Int $line, Supply $notifications)
     say "Receiving breakpoint notifications for $file:$line";
     start {
         react whenever $notifications.Supply -> $ev {
-            with $sup<frames> -> $frames {
+            with $ev<frames> -> $frames {
                 my @this-backtrace = format-backtrace($frames);
 
                 print-table my @chunks =


### PR DESCRIPTION
I think the problem is that in `else` the topic variable is taken from `with` (https://docs.raku.org/syntax/with%20orwith%20without): 

> As with the other chainable constructs, an else completing a with/if..orwith/elsif chain will itself topicalize to the value of the prior (failed) condition's topic (either the topic of with or the final orwith or elsif).