### PR TITLE
Run Rakudo from inside the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 App::MoarVM::Debug
 ==================
 
-The interactive MoarVM debugger installs a script called `raku-remote-debug` that allows a developer to start a Raku program in debugger mode, while in another window allows the developer to step through the program and perform various types of introspection.
+The interactive MoarVM debugger installs a script called `raku-remote-debug` that allows a developer to start a Raku program in debugger mode which allows the developer to step through the program and perform various types of introspection.
 
-Starting in debugger mode
+Starting the debugger
 -------------------------
 
     $ raku-remote-debug your-program.raku arg1 arg2
@@ -16,20 +16,6 @@ When it is started this way, it will show a text on STDERR such as:
 
     Running with debugging enabled at localhost port 27434
 
-Your program will not actually execute until you have entered the `resume` command in the debugger.
-
-Starting the debugger
----------------------
-
-    $ raku-remote-debug
-
-To start the debugger, call `raku-remote-debug` **without** any arguments. It will show you a text such as:
-
-    Welcome to the MoarVM Remote Debugger
-
-    Connecting to MoarVM remote on localhost port 27434
-    success!
-    >
 
 You would typically then set breakpoints or do some introspection. And then start the program by typing "resume" to lift the suspension of all threads in the program.
 
@@ -42,15 +28,15 @@ The debugger uses a single port to communicate between your program and the debu
 
 This means that on any given computer, only one program can be debugged this way, and only one debugger can run at the same time.
 
-Should you need to have more debuggers running at the same time, or for some reason you need to use another port, you can set the environment variable `MVM_DEBUG_PORT` to the port you'd like to use.
-
-To start your program:
-
-    $ MVM_DEBUG_PORT=4242 raku-remote-debug your-program.raku arg1 arg2
+Should you need to have more debuggers running at the same time, or for some reason you need to use another port, you can set the environment variable `MVM_DEBUG_PORT` to the port you'd like to use or pass `--port` argument to the debugger.
 
 To start the debugger:
 
-    $ MVM_DEBUG_PORT=4242 raku-remote-debug
+    $ MVM_DEBUG_PORT=4242 raku-remote-debug your-program.raku arg1 arg2
+
+  or
+
+    $ raku-remote-debug --port=2666 your-program.raku arg1 arg2
 
 Some hints
 ----------

--- a/bin/raku-remote-debug
+++ b/bin/raku-remote-debug
@@ -1,15 +1,14 @@
 use App::MoarVM::Debug;
 
-if @*ARGS -> @ARGS {
-    my $port := %*ENV<MVM_DEBUG_PORT> // 27434;
-    note "Running with debugging enabled at localhost port $port";
-    my $proc := run
-      $*EXECUTABLE.absolute,
-      "--debug-port=$port",
-      "--debug-suspend",
-      |@ARGS
-    ;
-    exit $proc.exitcode;
+multi sub MAIN(Str $path, Int :$port = %*ENV<MVM_DEBUG_PORT> // 27434,
+               Int :$abbreviate-length = 70, *@args) {
+  say "Incorrect file path $path" and return unless $path.IO.e;
+  my $proc := Proc::Async.new($*EXECUTABLE.absolute, "--debug-port=$port",
+                              "--debug-suspend", "$path", |@args).start;
+
+
+  MAIN $path, $port, $abbreviate-length, @args;
+  await $proc;
 }
 
 # vim: expandtab shiftwidth=4

--- a/bin/raku-remote-debug
+++ b/bin/raku-remote-debug
@@ -7,7 +7,7 @@ multi sub MAIN(Str $path, Int :$port = %*ENV<MVM_DEBUG_PORT> // 27434,
                               "--debug-suspend", "$path", |@args).start;
 
 
-  MAIN $path, $port, $abbreviate-length, @args;
+  MAIN $path, $port, :$abbreviate-length, @args;
   await $proc;
 }
 

--- a/lib/App/MoarVM/Debug.rakumod
+++ b/lib/App/MoarVM/Debug.rakumod
@@ -812,9 +812,7 @@ sub thread-list(--> Nil) {
 
 #- input handling --------------------------------------------------------------
 
-multi sub MAIN(Str $path, Int $port, Int :abbreviate-length($abvl), *@args) is export {
-    $abbreviate-length = $abvl;
-
+multi sub MAIN(Str $path, Int $port, Int $abbreviate-length, *@args) is export {
     say "Welcome to the MoarVM Remote Debugger!";
 
     unless %*ENV<_>:exists and %*ENV<_>.ends-with: 'rlwrap' {

--- a/lib/App/MoarVM/Debug.rakumod
+++ b/lib/App/MoarVM/Debug.rakumod
@@ -812,10 +812,7 @@ sub thread-list(--> Nil) {
 
 #- input handling --------------------------------------------------------------
 
-sub MAIN(
-  Int $port = %*ENV<MVM_DEBUG_PORT> // 27434,
-  Int :abbreviate-length($abvl) = 70
-) is export {
+multi sub MAIN(Str $path, Int $port, Int :abbreviate-length($abvl), *@args) is export {
     $abbreviate-length = $abvl;
 
     say "Welcome to the MoarVM Remote Debugger!";

--- a/lib/App/MoarVM/Debug.rakumod
+++ b/lib/App/MoarVM/Debug.rakumod
@@ -812,7 +812,9 @@ sub thread-list(--> Nil) {
 
 #- input handling --------------------------------------------------------------
 
-multi sub MAIN(Str $path, Int $port, Int $abbreviate-length, *@args) is export {
+multi sub MAIN(Str $path, Int $port, Int :abbreviate-length($abvl), *@args) is export {
+    $abbreviate-length = $abvl;
+
     say "Welcome to the MoarVM Remote Debugger!";
 
     unless %*ENV<_>:exists and %*ENV<_>.ends-with: 'rlwrap' {


### PR DESCRIPTION
Is there any good reason to NOT run Rakudo debugger from inside raku-remote-debug? The path is also passed to the main function because at some point I'd like to add showing where in the file we are.